### PR TITLE
Resolved height bin indexing error by ensuring target_output shape matches height_bin length

### DIFF
--- a/pylidar_tls_canopy/plant_profile.py
+++ b/pylidar_tls_canopy/plant_profile.py
@@ -45,9 +45,9 @@ class Jupp2009:
         self.zenith_bin = np.arange(self.min_z, self.max_z, self.zres) + self.zres / 2
         self.azimuth_bin = np.arange(0, 360, self.ares) + self.ares / 2 
 
-        nhbins = int( (max_h - min_h) // hres )
-        nzbins = int( (max_z - min_z) // zres )
-        nabins = int(360 // ares)        
+        nhbins = len(self.height_bin)
+        nzbins = len(self.zenith_bin)
+        nabins = len(self.azimuth_bin)
 
         self.target_output = np.zeros((nzbins, nabins, nhbins), dtype=np.float32)
         self.shot_output = np.zeros((nzbins,nabins,1), dtype=np.float32)


### PR DESCRIPTION
I was getting this error when setting `--heigh-resolution` to a small number e.g. 0.2

> Traceback (most recent call last):
>   File "pylidar-tls-canopy-old/pylidar.py", line 154, in <module>
>     run()
>   File "pylidar-tls-canopy-old/pylidar.py", line 140, in run
>     linear_pai = vpp.calcLinearPlantProfiles()
>                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "pylidar-tls-canopy-old/pylidar_tls_canopy/plant_profile.py", line 217, in calcLinearPlantProfiles
>     y = -kthetal[:,i]
>          ~~~~~~~^^^^^
> IndexError: index 249 is out of bounds for axis 1 with size 249

With the help of ChatGPT ... the solution was to change how nhbins, nzbins and nabins was calculated. 